### PR TITLE
add: data persistence in parent, student and teacher

### DIFF
--- a/Server/server_ed_platform/src/main/java/com/nocountry/server_ed_platform/services/impl/AuthServiceImpl.java
+++ b/Server/server_ed_platform/src/main/java/com/nocountry/server_ed_platform/services/impl/AuthServiceImpl.java
@@ -3,8 +3,14 @@ package com.nocountry.server_ed_platform.services.impl;
 import com.nocountry.server_ed_platform.dtos.LoginDTO;
 import com.nocountry.server_ed_platform.dtos.RegisterDTO;
 import com.nocountry.server_ed_platform.dtos.Response.AuthResponseDTO;
+import com.nocountry.server_ed_platform.entities.Parent;
+import com.nocountry.server_ed_platform.entities.Student;
+import com.nocountry.server_ed_platform.entities.Teacher;
 import com.nocountry.server_ed_platform.entities.UserEntity;
 import com.nocountry.server_ed_platform.enumarations.UserRole;
+import com.nocountry.server_ed_platform.repositories.ParentRepo;
+import com.nocountry.server_ed_platform.repositories.StudentRepo;
+import com.nocountry.server_ed_platform.repositories.TeacherRepo;
 import com.nocountry.server_ed_platform.repositories.UserRepository;
 import com.nocountry.server_ed_platform.services.AuthService;
 import com.nocountry.server_ed_platform.config.jwt.service.JwtService;
@@ -24,6 +30,9 @@ public class AuthServiceImpl implements AuthService {
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
+    private final TeacherRepo teacherRepo;
+    private final StudentRepo studentRepo;
+    private final ParentRepo parentRepo;
 
     public AuthResponseDTO login(LoginDTO request) {
         authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
@@ -49,6 +58,11 @@ public class AuthServiceImpl implements AuthService {
                 .role(UserRole.valueOf(request.getRol().toUpperCase()))
                 .build();
         userRepository.save(user);
+
+        if (request.getRol().equalsIgnoreCase("TEACHER")) teacherRepo.save(new Teacher());
+        if (request.getRol().equalsIgnoreCase("PARENT")) parentRepo.save(new Parent());
+        if (request.getRol().equalsIgnoreCase("STUDENT")) studentRepo.save(new Student());
+
         return AuthResponseDTO.builder()
                 .accessToken(jwtService.getToken(user))
                 .tokenType("Bearer")


### PR DESCRIPTION
Una vez creado un usuario, se verificará su rol y se creará una entidad vacía (ya sea para un padre, estudiante o profesor). Posteriormente, el usuario deberá completar los datos correspondientes, dependiendo del rol seleccionado al crear la cuenta.